### PR TITLE
Fix Bot initialization for aiogram 3.7

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 import asyncio
 
 from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
 
 from bot.handlers import router
 from config.config import BOT_TOKEN
 
 
 async def main() -> None:
-    bot = Bot(BOT_TOKEN, parse_mode="HTML")
+    bot = Bot(BOT_TOKEN, default=DefaultBotProperties(parse_mode="HTML"))
     dp = Dispatcher()
     dp.include_router(router)
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- use `DefaultBotProperties` to set HTML parse mode during bot initialization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3a68458883289cd27a4dcb0e7b20